### PR TITLE
Set isRestricted to true when query string has key

### DIFF
--- a/client.js
+++ b/client.js
@@ -42,6 +42,12 @@ $(document).ready(function() {
 		var addr = getUrlParameter('address');
 		var sidekey = getUrlParameter('key');
 		if(addr != null) {
+
+      var isRestrictedRequested = typeof sidekey !== 'undefined';
+      if (isRestrictedRequested) {
+        isRestricted = true;
+      }
+
 			doFetch(addr, sidekey);
 		}
 	});


### PR DESCRIPTION
It should be possible to show a restricted MAM channel when the query
string parameters address and key are available. Because the
isRestricted global variable is only set to true when selection
restricted in the dropdown this didn't work any more. This commit fixes
that by setting isRestricted to true when an address and sidekey are
available in the query string.